### PR TITLE
fixes issue with addressData in checkout

### DIFF
--- a/view/frontend/web/js/view/checkout/shipping/parcelshop.js
+++ b/view/frontend/web/js/view/checkout/shipping/parcelshop.js
@@ -132,12 +132,11 @@ define([
 				{
 					e.preventDefault();
 					var shippingAddressData = checkoutData.getShippingAddressFromData();
-
 					var data = {};
-					if(shippingAddressData !== null) {
-                        data['postcode'] = shippingAddressData.postcode;
-                        data['countryId'] = shippingAddressData.country_id;
-                        data['street'] = shippingAddressData.street[0];
+					if(shippingAddressData !== null && quote.shippingAddress() !== null) {
+                        data['postcode'] = shippingAddressData.postcode !== "" ? shippingAddressData.postcode : quote.shippingAddress().postcode;
+                        data['countryId'] = shippingAddressData.country_id !== "" ? shippingAddressData.country_id : quote.shippingAddress().country_id;
+                        data['street'] = shippingAddressData.street[0] !== "" ? shippingAddressData.street[0] : quote.shippingAddress().street[0];
                     }
 
 					$('#get_parcels_link').hide();

--- a/view/frontend/web/js/view/checkout/shipping/parcelshop.js
+++ b/view/frontend/web/js/view/checkout/shipping/parcelshop.js
@@ -83,10 +83,10 @@ define([
 					var shippingAddressData = checkoutData.getShippingAddressFromData();
 
 					window.dpdShippingAddress = parcelShop;
-					
+
 					var newShippingAddress = {
-									firstName:"DPD Parcelshop: ", 
-									lastName: parcelShop.company, 
+									firstName:"DPD Parcelshop: ",
+									lastName: parcelShop.company,
 									street: {0:parcelShop.houseno, 1:""},
 									postcode: parcelShop.zipcode,
 									city: parcelShop.city,
@@ -131,8 +131,14 @@ define([
 				function getParcels(e)
 				{
 					e.preventDefault();
+					var shippingAddressData = checkoutData.getShippingAddressFromData();
 
-					var shippingAddress = quote.shippingAddress();
+					var data = {};
+					if(shippingAddressData !== null) {
+                        data['postcode'] = shippingAddressData.postcode;
+                        data['countryId'] = shippingAddressData.country_id;
+                        data['street'] = shippingAddressData.street[0];
+                    }
 
 					$('#get_parcels_link').hide();
 
@@ -140,11 +146,7 @@ define([
 						method: 'POST',
 						showLoader: true, // enable loader
 						url : window.checkoutConfig.dpd_parcelshop_url,
-						data : {
-							postcode: shippingAddress.postcode,
-							countryId: shippingAddress.countryId,
-							street:	shippingAddress.street
-						}
+						data : data
 					}).done(function (response) {
 						var map_canvas = $('#map_canvas');
 

--- a/view/frontend/web/js/view/checkout/shipping/parcelshop.js
+++ b/view/frontend/web/js/view/checkout/shipping/parcelshop.js
@@ -131,24 +131,27 @@ define([
 				function getParcels(e)
 				{
 					e.preventDefault();
-                    var shippingAddressData = quote.shippingAddress();
+					var shippingAddressData = quote.shippingAddress();
 					var data = {};
 
-					//Because magnto is not consistent in its use of variables, we'll have to define the countryId.
+					//Because magento is not consistent in its use of variables, we'll have to define the countryId.
 					var countryId;
-					if(shippingAddressData === null) {
-                        shippingAddressData = checkoutData.getShippingAddressFromData();
-                        countryId = shippingAddressData.country_id;
-                    } else {
-						countryId = shippingAddressData.countryId;
+					if(shippingAddressData !== null) {
+						//we use the postcode to check whether these fields are filled in, if not use the checkoutData
+						 if(typeof shippingAddressData.postcode === 'undefined') {
+								shippingAddressData = checkoutData.getShippingAddressFromData();
+								countryId = shippingAddressData.country_id;
+						 }
+						 else {
+							countryId = shippingAddressData.countryId;
+						}
 					}
 
 					data['postcode'] =  shippingAddressData.postcode;
 					data['countryId'] = countryId;
-					if(shippingAddressData.street !== null) {
+					if(shippingAddressData.street !== null && typeof shippingAddressData.street !== 'undefined') {
 						data['street'] =  shippingAddressData.street[0];
 					}
-
 
 					$('#get_parcels_link').hide();
 
@@ -207,7 +210,6 @@ define([
 							map_canvas.html(response.error_message);
 						}
 					});
-
 				};
 			});
 

--- a/view/frontend/web/js/view/checkout/shipping/parcelshop.js
+++ b/view/frontend/web/js/view/checkout/shipping/parcelshop.js
@@ -131,13 +131,24 @@ define([
 				function getParcels(e)
 				{
 					e.preventDefault();
-					var shippingAddressData = checkoutData.getShippingAddressFromData();
+                    var shippingAddressData = quote.shippingAddress();
 					var data = {};
-					if(shippingAddressData !== null && quote.shippingAddress() !== null) {
-                        data['postcode'] = shippingAddressData.postcode !== "" ? shippingAddressData.postcode : quote.shippingAddress().postcode;
-                        data['countryId'] = shippingAddressData.country_id !== "" ? shippingAddressData.country_id : quote.shippingAddress().country_id;
-                        data['street'] = shippingAddressData.street[0] !== "" ? shippingAddressData.street[0] : quote.shippingAddress().street[0];
-                    }
+
+					//Because magnto is not consistent in its use of variables, we'll have to define the countryId.
+					var countryId;
+					if(shippingAddressData === null) {
+                        shippingAddressData = checkoutData.getShippingAddressFromData();
+                        countryId = shippingAddressData.country_id;
+                    } else {
+						countryId = shippingAddressData.countryId;
+					}
+
+					data['postcode'] =  shippingAddressData.postcode;
+					data['countryId'] = countryId;
+					if(shippingAddressData.street !== null) {
+						data['street'] =  shippingAddressData.street[0];
+					}
+
 
 					$('#get_parcels_link').hide();
 


### PR DESCRIPTION
Hi guys,

I created a PR for an issue we have in Magento 2.2.2.

### The Issue

When a (guest) customer fills in the address form, selects the DPD Pickup shipping method and clicks 'Click here to select your Parcelshop', the map won't get rendered and no notification is shown.

## The fix
When trying to get the Parcel shops from the customer's address, the shipping address is fetched from quote, but the fields might be undefined if the customer didn't log-in / go to the billing step.

In this PR, the shipping Address is fetched from the checkoutData, which is being updated when the address fields are changed and is immediately accessible. + when the checkoutData is NULL, the properties of the object won't be set. The last one is important because in the [controller](https://github.com/DPDBeNeLux/magento2-shipping/blob/995b811/Controller/Parcelshops/Index.php#L99) the data from the request is checked. When the keys don't exist in the data, the controller will show an error message, which isn't the case right now.

This fixes our problem with the map not being rendered.

Thx in advance!

Tristan