### PR TITLE
Fix error installation on prefixed DB

### DIFF
--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -369,7 +369,7 @@ class UpgradeSchema implements UpgradeSchemaInterface
 
         #16402
         if (version_compare($context->getVersion(), '1.1.1') < 0) {
-            if (!$setup->getConnection()->tableColumnExists('dpd_shipment_label', 'label_path')) {
+            if (!$setup->getConnection()->tableColumnExists($setup->getTable('dpd_shipment_label'), 'label_path')) {
                 $setup->getConnection()->addColumn($setup->getTable('dpd_shipment_label'), 'label_path', [
                     'type'      => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
                     'nullable'  => true,


### PR DESCRIPTION
Installation stopped if Magento has DB prefix.

Error message: 

    Upgrading schema... SQLSTATE[42S02]: Base table or view not found: 1146 Table 'oms_db.dpd_shipment_label' doesn't exist, query was: DESCRIBE `dpd_shipment_label`