### PR TITLE
[BUGFIX] - Changed telephone customer_address attribute value in observer from '' to '-…

### DIFF
--- a/Observer/SalesOrderAddressSaveBefore.php
+++ b/Observer/SalesOrderAddressSaveBefore.php
@@ -84,6 +84,6 @@ class SalesOrderAddressSaveBefore implements ObserverInterface
         }
 
         // empty this otherwise you'd get customer data and DPD parcelshop data mixed up
-        $shippingAddress->setTelephone('');
+        $shippingAddress->setTelephone('-');
     }
 }


### PR DESCRIPTION
…' in case the attribute is required which otherwise would prevent the order from being able to be placed

Based on https://github.com/DPDBeNeLux/magento2-shipping/issues/49
https://github.com/CsSatter/magento2-shipping/tree/bugfix/DPD_Pickup_telephone is also available to keep the value as it currently is, however it'll only overwrite it if the attribute isn't set to be required.