### PR TITLE
Set proper requirement versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,9 +2,9 @@
   "name": "dpdbenelux/magento2-shipping",
   "description": "DPD Magento2 Shipping extension",
   "require": {
-      "php": ">=7.0.13",
-      "setasign/fpdi-fpdf": "2.1",
-      "zendframework/zend-barcode" : "2.7"
+      "php": "7.0.2|7.0.4|~7.0.6|^7.1.0",
+      "setasign/fpdi-fpdf": "^2.1",
+      "zendframework/zend-barcode" : "^2.7"
   },
   "type": "magento2-module",
   "license": "GPL-3.0-or-later",


### PR DESCRIPTION
This way you avoid having to update your composer.json every single release of your dependencies, without really being in danger of having incompatible versions.

The PHP version is simply the recommended version for every Magento 2 site.